### PR TITLE
Add OpenRouter integration for poster generation with GPT-4o-mini

### DIFF
--- a/.env-example/.env.example
+++ b/.env-example/.env.example
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_api_key_here

--- a/README_POSTER.md
+++ b/README_POSTER.md
@@ -1,0 +1,73 @@
+# Paper2Poster: Academic Poster Generator
+
+This project converts academic research papers into visually appealing academic posters using GPT-4o-mini via OpenRouter.
+
+## Generated Posters
+
+Three different poster versions have been created:
+
+1. **Basic Poster** (`poster_output.pptx`): A simple poster with basic formatting
+2. **Enhanced Poster** (`enhanced_poster.pptx`): A more visually appealing poster with better layout
+3. **Final Poster** (`final_poster.pptx`): A professionally designed poster with color-coded sections and visual elements
+
+## How to Use
+
+### Prerequisites
+
+- Python 3.6+
+- OpenRouter API key (set in `.env` file)
+- Required Python packages: python-dotenv, openai, pptx, pdf2image, pdfminer.six
+
+### Setup
+
+1. Clone this repository
+2. Install dependencies:
+   ```
+   pip install python-dotenv openai python-pptx pdf2image pdfminer.six
+   ```
+3. Create a `.env` file with your OpenRouter API key:
+   ```
+   OPENROUTER_API_KEY=your_api_key_here
+   ```
+
+### Generate a Poster
+
+1. Place your research paper PDF in the `dataset/paper/` directory
+2. Run one of the following scripts:
+
+#### Basic Poster
+```
+python simple_poster.py dataset/paper/your_paper.pdf
+```
+
+#### Enhanced Poster
+```
+python extract_full_pptx_text.py  # Extract content from basic poster
+python create_enhanced_poster.py  # Create enhanced poster
+```
+
+#### Final Poster
+```
+python create_final_poster.py  # Create final poster with visual enhancements
+```
+
+## Script Descriptions
+
+- `simple_poster.py`: Extracts text from PDF and generates a basic poster
+- `extract_full_pptx_text.py`: Extracts content from the generated PPTX
+- `create_enhanced_poster.py`: Creates an enhanced poster with better layout
+- `create_final_poster.py`: Creates a professionally designed poster with visual elements
+
+## Converting to PDF
+
+To convert the PPTX to PDF for viewing:
+
+```
+libreoffice --headless --convert-to pdf your_poster.pptx
+```
+
+## Notes
+
+- The text extraction process may not capture all content from complex PDFs
+- The poster generation is optimized for research papers with standard sections (title, abstract, introduction, methodology, results, conclusion, references)
+- You may need to adjust the layout parameters in the scripts for papers with different structures

--- a/create_enhanced_poster.py
+++ b/create_enhanced_poster.py
@@ -1,0 +1,135 @@
+import json
+import os
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+
+# Load the extracted content
+with open('extracted_poster_content.json', 'r') as f:
+    content = json.load(f)
+
+# Create a presentation
+prs = Presentation()
+
+# Set slide dimensions to a standard poster size (36x24 inches)
+prs.slide_width = Inches(36)
+prs.slide_height = Inches(24)
+
+# Add a slide
+slide_layout = prs.slide_layouts[6]  # blank layout
+slide = prs.slides.add_slide(slide_layout)
+
+# Define colors
+TITLE_COLOR = RGBColor(0, 0, 128)  # Navy Blue
+SECTION_COLOR = RGBColor(0, 51, 102)  # Dark Blue
+TEXT_COLOR = RGBColor(0, 0, 0)  # Black
+BACKGROUND_COLOR = RGBColor(255, 255, 255)  # White
+
+# Set background color
+background = slide.background
+fill = background.fill
+fill.solid()
+fill.fore_color.rgb = BACKGROUND_COLOR
+
+# Add title
+title_box = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(34), Inches(2))
+title_frame = title_box.text_frame
+title_frame.word_wrap = True
+title_para = title_frame.paragraphs[0]
+title_para.alignment = PP_ALIGN.CENTER
+title_run = title_para.add_run()
+title_run.text = content["title"].strip()
+title_run.font.size = Pt(60)
+title_run.font.bold = True
+title_run.font.color.rgb = TITLE_COLOR
+
+# Add authors
+authors_box = slide.shapes.add_textbox(Inches(1), Inches(3), Inches(34), Inches(1))
+authors_frame = authors_box.text_frame
+authors_para = authors_frame.paragraphs[0]
+authors_para.alignment = PP_ALIGN.CENTER
+authors_run = authors_para.add_run()
+authors_run.text = content["authors"].strip()
+authors_run.font.size = Pt(36)
+authors_run.font.italic = True
+authors_run.font.color.rgb = TEXT_COLOR
+
+# Function to add a section
+def add_section(title, content_text, left, top, width, height):
+    # Add section box with border
+    section_box = slide.shapes.add_textbox(left, top, width, height)
+    
+    # Add title
+    text_frame = section_box.text_frame
+    text_frame.word_wrap = True
+    title_para = text_frame.paragraphs[0]
+    title_run = title_para.add_run()
+    title_run.text = title
+    title_run.font.size = Pt(40)
+    title_run.font.bold = True
+    title_run.font.color.rgb = SECTION_COLOR
+    
+    # Add content
+    content_para = text_frame.add_paragraph()
+    content_para.space_before = Pt(12)
+    content_run = content_para.add_run()
+    content_run.text = content_text.replace(title, "").strip()
+    content_run.font.size = Pt(28)
+    content_run.font.color.rgb = TEXT_COLOR
+    
+    return section_box
+
+# Layout sections
+# Abstract (top left)
+abstract_box = add_section(
+    "Abstract", 
+    content["abstract"], 
+    Inches(1), Inches(4.5), 
+    Inches(10), Inches(6)
+)
+
+# Introduction (top center)
+intro_box = add_section(
+    "Introduction", 
+    content["introduction"], 
+    Inches(12), Inches(4.5), 
+    Inches(12), Inches(6)
+)
+
+# Methodology (top right)
+method_box = add_section(
+    "Methodology", 
+    content["methodology"], 
+    Inches(25), Inches(4.5), 
+    Inches(10), Inches(6)
+)
+
+# Results (bottom left)
+results_box = add_section(
+    "Results", 
+    content["results"], 
+    Inches(1), Inches(11.5), 
+    Inches(16), Inches(6)
+)
+
+# Conclusion (bottom center)
+conclusion_box = add_section(
+    "Conclusion", 
+    content["conclusion"], 
+    Inches(18), Inches(11.5), 
+    Inches(17), Inches(6)
+)
+
+# References (bottom)
+references_box = add_section(
+    "References", 
+    content["references"], 
+    Inches(1), Inches(18.5), 
+    Inches(34), Inches(4)
+)
+
+# Save the presentation
+output_path = "enhanced_poster.pptx"
+prs.save(output_path)
+print(f"Enhanced poster saved to {output_path}")

--- a/create_final_poster.py
+++ b/create_final_poster.py
@@ -1,0 +1,208 @@
+import json
+import os
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+
+# Load the extracted content
+with open('extracted_poster_content.json', 'r') as f:
+    content = json.load(f)
+
+# Create a presentation
+prs = Presentation()
+
+# Set slide dimensions to a standard poster size (36x24 inches)
+prs.slide_width = Inches(36)
+prs.slide_height = Inches(24)
+
+# Add a slide
+slide_layout = prs.slide_layouts[6]  # blank layout
+slide = prs.slides.add_slide(slide_layout)
+
+# Define colors
+PRIMARY_COLOR = RGBColor(25, 25, 112)  # Midnight Blue
+SECONDARY_COLOR = RGBColor(70, 130, 180)  # Steel Blue
+ACCENT_COLOR = RGBColor(0, 0, 128)  # Navy
+TEXT_COLOR = RGBColor(0, 0, 0)  # Black
+BACKGROUND_COLOR = RGBColor(240, 248, 255)  # Alice Blue
+
+# Set background color
+background = slide.background
+fill = background.fill
+fill.solid()
+fill.fore_color.rgb = BACKGROUND_COLOR
+
+# Add a header bar
+header = slide.shapes.add_shape(
+    1,  # Rectangle
+    Inches(0), Inches(0), 
+    Inches(36), Inches(3)
+)
+header_fill = header.fill
+header_fill.solid()
+header_fill.fore_color.rgb = PRIMARY_COLOR
+
+# Add title
+title_box = slide.shapes.add_textbox(Inches(1), Inches(0.5), Inches(34), Inches(2))
+title_frame = title_box.text_frame
+title_frame.word_wrap = True
+title_para = title_frame.paragraphs[0]
+title_para.alignment = PP_ALIGN.CENTER
+title_run = title_para.add_run()
+title_run.text = content["title"].strip()
+title_run.font.size = Pt(60)
+title_run.font.bold = True
+title_run.font.color.rgb = RGBColor(255, 255, 255)  # White
+
+# Add authors
+authors_box = slide.shapes.add_textbox(Inches(1), Inches(3.2), Inches(34), Inches(1))
+authors_frame = authors_box.text_frame
+authors_para = authors_frame.paragraphs[0]
+authors_para.alignment = PP_ALIGN.CENTER
+authors_run = authors_para.add_run()
+authors_run.text = content["authors"].strip()
+authors_run.font.size = Pt(36)
+authors_run.font.italic = True
+authors_run.font.color.rgb = TEXT_COLOR
+
+# Function to add a section with a colored header
+def add_section(title, content_text, left, top, width, height, color=SECONDARY_COLOR):
+    # Add section box with border and rounded corners
+    section_box = slide.shapes.add_shape(
+        1,  # Rectangle
+        left, top, 
+        width, height
+    )
+    section_box.fill.solid()
+    section_box.fill.fore_color.rgb = RGBColor(255, 255, 255)  # White
+    section_box.line.color.rgb = color
+    section_box.line.width = Pt(3)
+    
+    # Add section header
+    header_box = slide.shapes.add_shape(
+        1,  # Rectangle
+        left, top, 
+        width, Inches(1)
+    )
+    header_box.fill.solid()
+    header_box.fill.fore_color.rgb = color
+    header_box.line.color.rgb = color
+    
+    # Add title
+    title_box = slide.shapes.add_textbox(
+        left + Inches(0.2), 
+        top + Inches(0.2), 
+        width - Inches(0.4), 
+        Inches(0.6)
+    )
+    title_frame = title_box.text_frame
+    title_para = title_frame.paragraphs[0]
+    title_para.alignment = PP_ALIGN.CENTER
+    title_run = title_para.add_run()
+    title_run.text = title
+    title_run.font.size = Pt(40)
+    title_run.font.bold = True
+    title_run.font.color.rgb = RGBColor(255, 255, 255)  # White
+    
+    # Add content
+    content_box = slide.shapes.add_textbox(
+        left + Inches(0.5), 
+        top + Inches(1.2), 
+        width - Inches(1), 
+        height - Inches(1.5)
+    )
+    content_frame = content_box.text_frame
+    content_frame.word_wrap = True
+    content_para = content_frame.paragraphs[0]
+    content_run = content_para.add_run()
+    content_run.text = content_text.replace(title, "").strip()
+    content_run.font.size = Pt(28)
+    content_run.font.color.rgb = TEXT_COLOR
+
+# Layout sections
+# Abstract (top left)
+abstract_box = add_section(
+    "Abstract", 
+    content["abstract"], 
+    Inches(1), Inches(4.5), 
+    Inches(10), Inches(6),
+    SECONDARY_COLOR
+)
+
+# Introduction (top center)
+intro_box = add_section(
+    "Introduction", 
+    content["introduction"], 
+    Inches(12), Inches(4.5), 
+    Inches(12), Inches(6),
+    SECONDARY_COLOR
+)
+
+# Methodology (top right)
+method_box = add_section(
+    "Methodology", 
+    content["methodology"], 
+    Inches(25), Inches(4.5), 
+    Inches(10), Inches(6),
+    SECONDARY_COLOR
+)
+
+# Results (bottom left)
+results_box = add_section(
+    "Results", 
+    content["results"], 
+    Inches(1), Inches(11.5), 
+    Inches(16), Inches(6),
+    ACCENT_COLOR
+)
+
+# Conclusion (bottom center)
+conclusion_box = add_section(
+    "Conclusion", 
+    content["conclusion"], 
+    Inches(18), Inches(11.5), 
+    Inches(17), Inches(6),
+    ACCENT_COLOR
+)
+
+# Add a footer bar
+footer = slide.shapes.add_shape(
+    1,  # Rectangle
+    Inches(0), Inches(18.5), 
+    Inches(36), Inches(5.5)
+)
+footer_fill = footer.fill
+footer_fill.solid()
+footer_fill.fore_color.rgb = PRIMARY_COLOR
+
+# References (bottom)
+references_title_box = slide.shapes.add_textbox(
+    Inches(1), Inches(19), 
+    Inches(34), Inches(1)
+)
+references_title_frame = references_title_box.text_frame
+references_title_para = references_title_frame.paragraphs[0]
+references_title_para.alignment = PP_ALIGN.CENTER
+references_title_run = references_title_para.add_run()
+references_title_run.text = "References"
+references_title_run.font.size = Pt(40)
+references_title_run.font.bold = True
+references_title_run.font.color.rgb = RGBColor(255, 255, 255)  # White
+
+references_box = slide.shapes.add_textbox(
+    Inches(1), Inches(20), 
+    Inches(34), Inches(3)
+)
+references_frame = references_box.text_frame
+references_para = references_frame.paragraphs[0]
+references_para.alignment = PP_ALIGN.CENTER
+references_run = references_para.add_run()
+references_run.text = content["references"].replace("References", "").strip()
+references_run.font.size = Pt(28)
+references_run.font.color.rgb = RGBColor(255, 255, 255)  # White
+
+# Save the presentation
+output_path = "final_poster.pptx"
+prs.save(output_path)
+print(f"Final poster saved to {output_path}")

--- a/custom_openrouter.py
+++ b/custom_openrouter.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from dotenv import load_dotenv
+from camel.types import ModelPlatformType
+from camel.configs import OpenRouterConfig
+from utils.wei_utils import get_agent_config
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Create a custom model configuration for OpenRouter with GPT-4o-mini
+def get_custom_openrouter_config():
+    agent_config = {
+        'model_type': "openai/gpt-4o-mini",  # OpenRouter path to GPT-4o-mini
+        'model_platform': ModelPlatformType.OPENROUTER,
+        'model_config': OpenRouterConfig().as_dict(),
+    }
+    return agent_config
+
+if __name__ == "__main__":
+    # Check if we have the required environment variables
+    if not os.getenv("OPENROUTER_API_KEY"):
+        print("Error: OPENROUTER_API_KEY environment variable is not set.")
+        sys.exit(1)
+    
+    # Get the paper path from command line arguments
+    if len(sys.argv) < 2:
+        print("Usage: python custom_openrouter.py <path_to_paper.pdf>")
+        sys.exit(1)
+    
+    paper_path = sys.argv[1]
+    
+    # Run the poster generation pipeline with our custom configuration
+    cmd = f"""
+    python -m PosterAgent.new_pipeline \
+        --poster_path="{paper_path}" \
+        --model_name_t="openai/gpt-4o-mini" \
+        --model_name_v="openai/gpt-4o-mini" \
+        --poster_width_inches=48 \
+        --poster_height_inches=36
+    """
+    
+    print(f"Running command: {cmd}")
+    os.system(cmd)

--- a/extract_content.py
+++ b/extract_content.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import json
+import requests
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# Get the OpenRouter API key
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+if not openrouter_api_key:
+    print("Error: OPENROUTER_API_KEY environment variable is not set.")
+    sys.exit(1)
+
+def call_openrouter_api(pdf_text):
+    """Call the OpenRouter API with GPT-4o-mini to generate poster content."""
+    headers = {
+        "Authorization": f"Bearer {openrouter_api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://all-hands.dev",
+        "X-Title": "Paper2Poster"
+    }
+    
+    data = {
+        "model": "openai/gpt-4o-mini",
+        "messages": [
+            {
+                "role": "system", 
+                "content": "You are an expert at creating academic posters from research papers. Extract the key information and organize it into a clear, visually appealing academic poster structure."
+            },
+            {
+                "role": "user", 
+                "content": f"Create an academic poster from this research paper. Extract the title, authors, abstract, introduction, methodology, results, and conclusion. Format it as a JSON with the following structure: {{\"title\": \"\", \"authors\": \"\", \"abstract\": \"\", \"introduction\": \"\", \"methodology\": \"\", \"results\": \"\", \"conclusion\": \"\", \"references\": \"\"}}. Here's the paper content:\n\n{pdf_text}"
+            }
+        ],
+        "max_tokens": 2000,
+        "response_format": {"type": "json_object"}
+    }
+    
+    response = requests.post("https://openrouter.ai/api/v1/chat/completions", headers=headers, json=data)
+    
+    if response.status_code == 200:
+        content = response.json()["choices"][0]["message"]["content"]
+        return content
+    else:
+        print(f"Error calling OpenRouter API: {response.status_code}")
+        print(response.text)
+        return None
+
+# Read the PDF text from a file
+with open("dataset/paper/paper.txt", "r") as f:
+    pdf_text = f.read()
+
+# Call the API
+content = call_openrouter_api(pdf_text)
+
+# Save the JSON content to a file
+if content:
+    with open("poster_content.json", "w") as f:
+        f.write(content)
+    print("Content saved to poster_content.json")
+    
+    # Also print the parsed content
+    try:
+        data = json.loads(content)
+        print("\nPoster Content:")
+        print(f"Title: {data['title']}")
+        print(f"Authors: {data['authors']}")
+        print(f"Abstract: {data['abstract'][:100]}...")
+    except json.JSONDecodeError:
+        print("Error: Could not parse JSON content")
+else:
+    print("Error: No content generated")

--- a/extract_full_pptx_text.py
+++ b/extract_full_pptx_text.py
@@ -1,0 +1,63 @@
+import json
+from pptx import Presentation
+
+prs = Presentation('poster_output.pptx')
+poster_content = {
+    "title": "",
+    "authors": "",
+    "abstract": "",
+    "introduction": "",
+    "methodology": "",
+    "results": "",
+    "conclusion": "",
+    "references": ""
+}
+
+for slide in prs.slides:
+    for shape in slide.shapes:
+        if hasattr(shape, 'text_frame'):
+            text = shape.text_frame.text
+            
+            # Extract content based on section headers
+            if "Evaluating LLM Agent" in text:
+                poster_content["title"] = text
+            elif "Anonymous Authors" in text:
+                poster_content["authors"] = text
+            elif text.startswith("Abstract"):
+                poster_content["abstract"] = text
+            elif text.startswith("Introduction"):
+                poster_content["introduction"] = text
+            elif text.startswith("Methodology"):
+                poster_content["methodology"] = text
+            elif text.startswith("Results"):
+                poster_content["results"] = text
+            elif text.startswith("Conclusion"):
+                poster_content["conclusion"] = text
+            elif text.startswith("References"):
+                poster_content["references"] = text
+            
+            # Also check for paragraphs
+            for paragraph in shape.text_frame.paragraphs:
+                paragraph_text = paragraph.text
+                if paragraph_text.startswith("Abstract") or "Abstract" in paragraph_text and len(poster_content["abstract"]) == 0:
+                    poster_content["abstract"] = shape.text_frame.text
+                elif paragraph_text.startswith("Introduction") or "Introduction" in paragraph_text and len(poster_content["introduction"]) == 0:
+                    poster_content["introduction"] = shape.text_frame.text
+                elif paragraph_text.startswith("Methodology") or "Methodology" in paragraph_text and len(poster_content["methodology"]) == 0:
+                    poster_content["methodology"] = shape.text_frame.text
+                elif paragraph_text.startswith("Results") or "Results" in paragraph_text and len(poster_content["results"]) == 0:
+                    poster_content["results"] = shape.text_frame.text
+                elif paragraph_text.startswith("Conclusion") or "Conclusion" in paragraph_text and len(poster_content["conclusion"]) == 0:
+                    poster_content["conclusion"] = shape.text_frame.text
+                elif paragraph_text.startswith("References") or "References" in paragraph_text and len(poster_content["references"]) == 0:
+                    poster_content["references"] = shape.text_frame.text
+
+# Save the extracted content to a JSON file
+with open('extracted_poster_content.json', 'w') as f:
+    json.dump(poster_content, f, indent=2)
+
+# Print the extracted content
+for section, content in poster_content.items():
+    print(f"{section.upper()}:")
+    print(content[:200] + "..." if len(content) > 200 else content)
+    print()

--- a/extract_pptx_text.py
+++ b/extract_pptx_text.py
@@ -1,0 +1,12 @@
+import json
+from pptx import Presentation
+
+prs = Presentation('poster_output.pptx')
+
+for slide_num, slide in enumerate(prs.slides):
+    print(f"Slide {slide_num + 1}:")
+    for shape_num, shape in enumerate(slide.shapes):
+        if hasattr(shape, 'text_frame'):
+            text = shape.text_frame.text
+            print(f"  Shape {shape_num + 1}: {text[:100]}{'...' if len(text) > 100 else ''}")
+    print()

--- a/openrouter_setup.py
+++ b/openrouter_setup.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Get the OpenRouter API key
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+if not openrouter_api_key:
+    print("Error: OPENROUTER_API_KEY environment variable is not set.")
+    sys.exit(1)
+
+# Create a file to set the OpenAI API key to the OpenRouter API key
+with open("/workspace/Paper2Poster/.env", "w") as f:
+    f.write(f"OPENAI_API_KEY={openrouter_api_key}\n")
+    f.write(f"OPENAI_API_BASE=https://openrouter.ai/api/v1\n")
+    f.write(f"OPENROUTER_API_KEY={openrouter_api_key}\n")
+
+print("OpenRouter API key has been set up as the OpenAI API key.")

--- a/simple_poster.py
+++ b/simple_poster.py
@@ -1,0 +1,217 @@
+import os
+import sys
+import json
+import requests
+import io
+from dotenv import load_dotenv
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+import pdf2image
+from pdfminer.high_level import extract_text
+
+# Load environment variables
+load_dotenv()
+
+# Get the OpenRouter API key
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+if not openrouter_api_key:
+    print("Error: OPENROUTER_API_KEY environment variable is not set.")
+    sys.exit(1)
+
+def extract_text_from_pdf(pdf_path):
+    """Extract text from the PDF using pdfminer."""
+    try:
+        # Extract text from PDF
+        text = extract_text(pdf_path)
+        
+        # Limit text length to avoid token limits
+        max_length = 10000
+        if len(text) > max_length:
+            text = text[:max_length] + "... [text truncated due to length]"
+        
+        print(f"Extracted {len(text)} characters from PDF")
+        return text
+    except Exception as e:
+        print(f"Error extracting text from PDF: {e}")
+        return "Error extracting text from PDF"
+
+def call_openrouter_api(prompt, pdf_text):
+    """Call the OpenRouter API with GPT-4o-mini to generate poster content."""
+    headers = {
+        "Authorization": f"Bearer {openrouter_api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://all-hands.dev",
+        "X-Title": "Paper2Poster"
+    }
+    
+    data = {
+        "model": "openai/gpt-4o-mini",
+        "messages": [
+            {
+                "role": "system", 
+                "content": "You are an expert at creating academic posters from research papers. Extract the key information and organize it into a clear, visually appealing academic poster structure."
+            },
+            {
+                "role": "user", 
+                "content": f"Create an academic poster from this research paper. Extract the title, authors, abstract, introduction, methodology, results, and conclusion. Format it as a JSON with the following structure: {{\"title\": \"\", \"authors\": \"\", \"abstract\": \"\", \"introduction\": \"\", \"methodology\": \"\", \"results\": \"\", \"conclusion\": \"\", \"references\": \"\"}}. Here's the paper content:\n\n{pdf_text}\n\n{prompt}"
+            }
+        ],
+        "max_tokens": 2000,
+        "response_format": {"type": "json_object"}
+    }
+    
+    response = requests.post("https://openrouter.ai/api/v1/chat/completions", headers=headers, json=data)
+    
+    if response.status_code == 200:
+        content = response.json()["choices"][0]["message"]["content"]
+        print(f"API Response: {content[:100]}...")  # Print the first 100 chars for debugging
+        return content
+    else:
+        print(f"Error calling OpenRouter API: {response.status_code}")
+        print(response.text)
+        return None
+
+def create_poster(content, output_path):
+    """Create a PowerPoint poster from the generated content."""
+    try:
+        # Parse the JSON content
+        poster_data = json.loads(content)
+        
+        # Create a new presentation
+        prs = Presentation()
+        
+        # Set slide dimensions for a poster (48x36 inches)
+        prs.slide_width = Inches(48)
+        prs.slide_height = Inches(36)
+        
+        # Add a slide
+        slide_layout = prs.slide_layouts[6]  # Blank layout
+        slide = prs.slides.add_slide(slide_layout)
+        
+        # Add title
+        title_box = slide.shapes.add_textbox(Inches(2), Inches(1), Inches(44), Inches(3))
+        title_frame = title_box.text_frame
+        title_para = title_frame.add_paragraph()
+        title_para.text = poster_data["title"]
+        title_para.alignment = PP_ALIGN.CENTER
+        title_para.font.size = Pt(72)
+        title_para.font.bold = True
+        title_para.font.color.rgb = RGBColor(0, 0, 128)  # Dark blue
+        
+        # Add authors
+        authors_box = slide.shapes.add_textbox(Inches(2), Inches(4), Inches(44), Inches(1))
+        authors_frame = authors_box.text_frame
+        authors_para = authors_frame.add_paragraph()
+        authors_para.text = poster_data["authors"]
+        authors_para.alignment = PP_ALIGN.CENTER
+        authors_para.font.size = Pt(40)
+        authors_para.font.italic = True
+        
+        # Add abstract
+        abstract_box = slide.shapes.add_textbox(Inches(2), Inches(6), Inches(44), Inches(4))
+        abstract_frame = abstract_box.text_frame
+        abstract_title = abstract_frame.add_paragraph()
+        abstract_title.text = "Abstract"
+        abstract_title.font.size = Pt(48)
+        abstract_title.font.bold = True
+        abstract_content = abstract_frame.add_paragraph()
+        abstract_content.text = poster_data["abstract"]
+        abstract_content.font.size = Pt(32)
+        
+        # Create a 2x2 grid for the remaining sections
+        # Introduction (top left)
+        intro_box = slide.shapes.add_textbox(Inches(2), Inches(11), Inches(21), Inches(10))
+        intro_frame = intro_box.text_frame
+        intro_title = intro_frame.add_paragraph()
+        intro_title.text = "Introduction"
+        intro_title.font.size = Pt(48)
+        intro_title.font.bold = True
+        intro_content = intro_frame.add_paragraph()
+        intro_content.text = poster_data["introduction"]
+        intro_content.font.size = Pt(28)
+        
+        # Methodology (top right)
+        method_box = slide.shapes.add_textbox(Inches(25), Inches(11), Inches(21), Inches(10))
+        method_frame = method_box.text_frame
+        method_title = method_frame.add_paragraph()
+        method_title.text = "Methodology"
+        method_title.font.size = Pt(48)
+        method_title.font.bold = True
+        method_content = method_frame.add_paragraph()
+        method_content.text = poster_data["methodology"]
+        method_content.font.size = Pt(28)
+        
+        # Results (bottom left)
+        results_box = slide.shapes.add_textbox(Inches(2), Inches(22), Inches(21), Inches(10))
+        results_frame = results_box.text_frame
+        results_title = results_frame.add_paragraph()
+        results_title.text = "Results"
+        results_title.font.size = Pt(48)
+        results_title.font.bold = True
+        results_content = results_frame.add_paragraph()
+        results_content.text = poster_data["results"]
+        results_content.font.size = Pt(28)
+        
+        # Conclusion (bottom right)
+        concl_box = slide.shapes.add_textbox(Inches(25), Inches(22), Inches(21), Inches(10))
+        concl_frame = concl_box.text_frame
+        concl_title = concl_frame.add_paragraph()
+        concl_title.text = "Conclusion"
+        concl_title.font.size = Pt(48)
+        concl_title.font.bold = True
+        concl_content = concl_frame.add_paragraph()
+        concl_content.text = poster_data["conclusion"]
+        concl_content.font.size = Pt(28)
+        
+        # References at the bottom
+        ref_box = slide.shapes.add_textbox(Inches(2), Inches(33), Inches(44), Inches(2))
+        ref_frame = ref_box.text_frame
+        ref_title = ref_frame.add_paragraph()
+        ref_title.text = "References"
+        ref_title.font.size = Pt(36)
+        ref_title.font.bold = True
+        ref_content = ref_frame.add_paragraph()
+        ref_content.text = poster_data["references"]
+        ref_content.font.size = Pt(20)
+        
+        # Save the presentation
+        prs.save(output_path)
+        print(f"Poster saved to {output_path}")
+        return True
+    except Exception as e:
+        print(f"Error creating poster: {e}")
+        return False
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python simple_poster.py <path_to_paper.pdf>")
+        sys.exit(1)
+    
+    pdf_path = sys.argv[1]
+    output_path = "poster_output.pptx"
+    
+    # Extract text from PDF
+    print("Extracting text from PDF...")
+    pdf_text = extract_text_from_pdf(pdf_path)
+    
+    # Call OpenRouter API
+    print("Generating poster content with GPT-4o-mini...")
+    prompt = "Create an academic poster from this research paper. Focus on the main contributions and findings."
+    content = call_openrouter_api(prompt, pdf_text)
+    
+    if content:
+        # Create poster
+        print("Creating poster...")
+        success = create_poster(content, output_path)
+        
+        if success:
+            print(f"Poster successfully created at {output_path}")
+        else:
+            print("Failed to create poster")
+    else:
+        print("Failed to generate poster content")
+
+if __name__ == "__main__":
+    main()

--- a/utils/wei_utils.py
+++ b/utils/wei_utils.py
@@ -174,6 +174,12 @@ def get_agent_config(model_type):
             'model_platform': ModelPlatformType.OPENROUTER,
             'model_config': OpenRouterConfig().as_dict(),
         }
+    elif model_type == 'openai/gpt-4o-mini':
+        agent_config = {
+            'model_type': "openai/gpt-4o-mini",
+            'model_platform': ModelPlatformType.OPENROUTER,
+            'model_config': OpenRouterConfig().as_dict(),
+        }
     else:
         agent_config = {
             'model_type': model_type,


### PR DESCRIPTION
This PR adds support for generating academic posters from research papers using OpenRouter with GPT-4o-mini.

## Features Added:
- Integration with OpenRouter API to use GPT-4o-mini for poster generation
- Simple script to extract text from PDF and generate a basic poster
- Enhanced poster generation with better layout and visual elements
- Final poster with professional design and color-coded sections
- Utility scripts for extracting and processing content
- Detailed README with instructions for usage

## How to Use:
1. Set up your OpenRouter API key in a `.env` file
2. Place your research paper PDF in the `dataset/paper/` directory
3. Run `simple_poster.py` to generate a basic poster
4. Run `create_enhanced_poster.py` or `create_final_poster.py` for more visually appealing posters

The implementation uses pdfminer for text extraction and python-pptx for poster generation.

## Example Output:
The scripts generate PPTX files that can be converted to PDF for viewing. The posters include sections for title, authors, abstract, introduction, methodology, results, conclusion, and references.

@rapturt9 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/241261953956405d8dd1cdfa1cec9b22)